### PR TITLE
ci: Changed release-please to use PAT.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
When a github action is triggered using the built in `github.token`, it is not allowed to trigger further events. This means that when release please is triggered, it can not then trigger a release of the repo. Therefore, I have changed it to use `secrets.PAT`, which does not have this limitation. 