### PR TITLE
ci: Add `prerun` to copy-content action

### DIFF
--- a/.github/workflows/copy-content.yml
+++ b/.github/workflows/copy-content.yml
@@ -34,11 +34,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: echo "branch_exists=$(gh api repos/${{ inputs.repo }}/branches/${{ inputs.branch }} --jq '.name' | wc -l | xargs)" >> $GITHUB_OUTPUT
+
       - name: Check if open PR exists
         id: check_pr
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: echo "pr_exists=$(gh pr list -R ${{ inputs.repo }} -H ${{ inputs.branch }} --json number -q length)" >> $GITHUB_OUTPUT
+
       - name: Checkout source repo
         uses: actions/checkout@v4
         with:
@@ -60,60 +62,44 @@ jobs:
           path: "destination"
           repository: ${{ inputs.repo }}
           token: ${{ secrets.PAT }}
+
       - name: Create branch in destination repo
         if: ${{ steps.check_branch.outputs.branch_exists == 0 }}
         run: |
           cd destination
           git checkout -b ${{ inputs.branch }}
 
-      - run: echo ${{inputs.prerun}}
       - name: Run pre-run command
         if: inputs.prerun != ''
         run: |
           cd destination
           eval ${{ inputs.prerun }}
+
       - name: Get current date
         id: date
-        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%d %b %Y, %H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Copy files
         run: cp -r source/${{ inputs.source_dir }}/* destination/${{ inputs.destination_dir }}
 
-      - name: Commit changes
+      - name: Stage destination changes
         run: |
           cd destination
           git config --global user.name "zeta-icons-bot"
           git config --global user.email "zeta-icons-bot@github.com"
           git add -A
+
+      - name: Check if there are changes
+        id: changed
+        run: |
+          cd destination
+          git diff --quiet . || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.changed.outputs.changed == 'true'
+        run: |
           git commit -m "deps(automated): ${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
           git push --set-upstream origin ${{inputs.branch}} -f
-
-      # - name: Push files if branch exists
-      #   uses: dmnemec/copy_file_to_another_repo_action@main
-      #   if: ${{ steps.check_branch.outputs.branch_exists != 0 }}
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.PAT }}
-      #   with:
-      #     source_file: ${{ inputs.source_dir }}
-      #     destination_repo: ${{ inputs.repo }}
-      #     destination_folder: ${{ inputs.destination_dir }}
-      #     destination_branch: ${{ inputs.branch }}
-      #     user_email: "zeta-tokens-bot@github.com"
-      #     user_name: "Zeta Tokens Bot"
-      #     commit_message: "deps(automated): ${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
-      # - name: Push files if branch does not exist
-      #   uses: dmnemec/copy_file_to_another_repo_action@main
-      #   if: ${{ steps.check_branch.outputs.branch_exists == 0 }}
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.PAT }}
-      #   with:
-      #     source_file: ${{ inputs.source_dir }}
-      #     destination_repo: ${{ inputs.repo }}
-      #     destination_folder: ${{ inputs.destination_dir }}
-      #     destination_branch_create: ${{ inputs.branch }}
-      #     user_email: "zeta-tokens-bot@github.com"
-      #     user_name: "Zeta Tokens Bot"
-      #     commit_message: "deps(automated): ${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
 
       - name: Open PR
         uses: thecanadianroot/open-pull-request-action@v1.1.1
@@ -126,6 +112,7 @@ jobs:
           labels: tokens
           body: "${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
           repository: ${{ inputs.repo }}
+
       - name: Add comment to existing PR
         env:
           GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/copy-content.yml
+++ b/.github/workflows/copy-content.yml
@@ -43,13 +43,29 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: "source"
-      - name: Checkout destination repo
+
+      - name: Checkout destination repo (Branch exists)
         uses: actions/checkout@v4
+        if: ${{ steps.check_branch.outputs.branch_exists != 0 }}
         with:
           path: "destination"
           repository: ${{ inputs.repo }}
           token: ${{ secrets.PAT }}
           ref: ${{ inputs.branch }}
+
+      - name: Checkout destination repo (Branch doesn't exist)
+        uses: actions/checkout@v4
+        if: ${{ steps.check_branch.outputs.branch_exists == 0 }}
+        with:
+          path: "destination"
+          repository: ${{ inputs.repo }}
+          token: ${{ secrets.PAT }}
+      - name: Create branch in destination repo
+        if: ${{ steps.check_branch.outputs.branch_exists == 0 }}
+        run: |
+          cd destination
+          git checkout -b ${{ inputs.branch }}
+
       - run: echo ${{inputs.prerun}}
       - name: Run pre-run command
         if: inputs.prerun != ''
@@ -70,9 +86,7 @@ jobs:
           git config --global user.email "zeta-icons-bot@github.com"
           git add -A
           git commit -m "deps(automated): ${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
-          git push
-
-      # --set-upstream origin ${{steps.branch_name.outputs.BRANCH_NAME}} -f
+          git push --set-upstream origin ${{inputs.branch}} -f
 
       # - name: Push files if branch exists
       #   uses: dmnemec/copy_file_to_another_repo_action@main

--- a/.github/workflows/copy-content.yml
+++ b/.github/workflows/copy-content.yml
@@ -18,6 +18,9 @@ on:
       commit_msg:
         required: true
         type: string
+      prerun:
+        required: false
+        type: string
     secrets:
       PAT:
         required: true
@@ -36,39 +39,68 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: echo "pr_exists=$(gh pr list -R ${{ inputs.repo }} -H ${{ inputs.branch }} --json number -q length)" >> $GITHUB_OUTPUT
-      - name: Checkout code
+      - name: Checkout source repo
         uses: actions/checkout@v4
-      # - name: Pull latest changes
-      #   run: git pull
+        with:
+          path: "source"
+      - name: Checkout destination repo
+        uses: actions/checkout@v4
+        with:
+          path: "destination"
+          repository: ${{ inputs.repo }}
+          token: ${{ secrets.PAT }}
+          ref: ${{ inputs.branch }}
+      - run: echo ${{inputs.prerun}}
+      - name: Run pre-run command
+        if: inputs.prerun != ''
+        run: |
+          cd destination
+          eval ${{ inputs.prerun }}
       - name: Get current date
         id: date
         run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-      - name: Push files if branch exists
-        uses: dmnemec/copy_file_to_another_repo_action@main
-        if: ${{ steps.check_branch.outputs.branch_exists != 0 }}
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.PAT }}
-        with:
-          source_file: ${{ inputs.source_dir }}
-          destination_repo: ${{ inputs.repo }}
-          destination_folder: ${{ inputs.destination_dir }}
-          destination_branch: ${{ inputs.branch }}
-          user_email: "zeta-tokens-bot@github.com"
-          user_name: "Zeta Tokens Bot"
-          commit_message: "deps(automated): ${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
-      - name: Push files if branch does not exist
-        uses: dmnemec/copy_file_to_another_repo_action@main
-        if: ${{ steps.check_branch.outputs.branch_exists == 0 }}
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.PAT }}
-        with:
-          source_file: ${{ inputs.source_dir }}
-          destination_repo: ${{ inputs.repo }}
-          destination_folder: ${{ inputs.destination_dir }}
-          destination_branch_create: ${{ inputs.branch }}
-          user_email: "zeta-tokens-bot@github.com"
-          user_name: "Zeta Tokens Bot"
-          commit_message: "deps(automated): ${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
+
+      - name: Copy files
+        run: cp -r source/${{ inputs.source_dir }}/* destination/${{ inputs.destination_dir }}
+
+      - name: Commit changes
+        run: |
+          cd destination
+          git config --global user.name "zeta-icons-bot"
+          git config --global user.email "zeta-icons-bot@github.com"
+          git add -A
+          git commit -m "deps(automated): ${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
+          git push
+
+      # --set-upstream origin ${{steps.branch_name.outputs.BRANCH_NAME}} -f
+
+      # - name: Push files if branch exists
+      #   uses: dmnemec/copy_file_to_another_repo_action@main
+      #   if: ${{ steps.check_branch.outputs.branch_exists != 0 }}
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.PAT }}
+      #   with:
+      #     source_file: ${{ inputs.source_dir }}
+      #     destination_repo: ${{ inputs.repo }}
+      #     destination_folder: ${{ inputs.destination_dir }}
+      #     destination_branch: ${{ inputs.branch }}
+      #     user_email: "zeta-tokens-bot@github.com"
+      #     user_name: "Zeta Tokens Bot"
+      #     commit_message: "deps(automated): ${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
+      # - name: Push files if branch does not exist
+      #   uses: dmnemec/copy_file_to_another_repo_action@main
+      #   if: ${{ steps.check_branch.outputs.branch_exists == 0 }}
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.PAT }}
+      #   with:
+      #     source_file: ${{ inputs.source_dir }}
+      #     destination_repo: ${{ inputs.repo }}
+      #     destination_folder: ${{ inputs.destination_dir }}
+      #     destination_branch_create: ${{ inputs.branch }}
+      #     user_email: "zeta-tokens-bot@github.com"
+      #     user_name: "Zeta Tokens Bot"
+      #     commit_message: "deps(automated): ${{inputs.commit_msg}} ${{ steps.date.outputs.date }}"
+
       - name: Open PR
         uses: thecanadianroot/open-pull-request-action@v1.1.1
         if: ${{ steps.check_pr.outputs.pr_exists == 0 }}

--- a/.github/workflows/update_zds_android.yml
+++ b/.github/workflows/update_zds_android.yml
@@ -17,3 +17,4 @@ jobs:
       source_dir: "./outputs/android/."
       destination_dir: "components/src/main/res/drawable"
       commit_msg: "Update icons"
+      prerun: rm -f components/src/main/res/drawable/ic_*.xml


### PR DESCRIPTION
`prerun` allows arbitrary code to be executed on the destination repo.
This is added so that in zds-android, the old icon files can be deleted safely, without deleting other content in the same directory